### PR TITLE
feat: handle refresh token in cookies 🥨

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bcryptjs": "^3.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "cookie-parser": "^1.4.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
@@ -48,6 +49,7 @@
     "@nestjs/testing": "^11.0.1",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
+    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -72,6 +75,9 @@ importers:
       '@swc/core':
         specifier: ^1.10.7
         version: 1.11.29
+      '@types/cookie-parser':
+        specifier: ^1.4.9
+        version: 1.4.9(@types/express@5.0.2)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.2
@@ -1127,6 +1133,11 @@ packages:
   '@types/conventional-commits-parser@5.0.1':
     resolution: {integrity: sha512-7uz5EHdzz2TqoMfV7ee61Egf5y6NkcO4FB/1iCCQnbeiI1F3xzv3vK5dBCXUCLQgGYS+mUeigK1iKQzvED+QnQ==}
 
+  '@types/cookie-parser@1.4.9':
+    resolution: {integrity: sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==}
+    peerDependencies:
+      '@types/express': '*'
+
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
@@ -1751,6 +1762,13 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-parser@1.4.7:
+    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
+    engines: {node: '>= 0.8.0'}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -4939,6 +4957,10 @@ snapshots:
     dependencies:
       '@types/node': 22.15.29
 
+  '@types/cookie-parser@1.4.9(@types/express@5.0.2)':
+    dependencies:
+      '@types/express': 5.0.2
+
   '@types/cookiejar@2.1.5': {}
 
   '@types/eslint-scope@3.7.7':
@@ -5675,6 +5697,13 @@ snapshots:
       split2: 4.2.0
 
   convert-source-map@2.0.0: {}
+
+  cookie-parser@1.4.7:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+
+  cookie-signature@1.0.6: {}
 
   cookie-signature@1.2.2: {}
 

--- a/src/adapters/prisma/prisma-refresh-token.repository.ts
+++ b/src/adapters/prisma/prisma-refresh-token.repository.ts
@@ -44,9 +44,8 @@ export class PrismaRefreshTokenRepository implements RefreshTokenRepository {
   }
 
   async expireNow(token: string) {
-    await this.prisma.refreshToken.updateMany({
+    await this.prisma.refreshToken.delete({
       where: { token },
-      data: { expiresAt: new Date() },
     });
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,17 +8,22 @@ import { ValidationPipe } from '@nestjs/common';
 import { RolesGuard } from './adapters/api/guards/roles.guard';
 import { Reflector } from '@nestjs/core';
 import { JwtAuthGuard } from './adapters/api/guards/jwt-auth.guard';
+import cookieParser from 'cookie-parser';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalFilters(new DomainErrorFilter());
   app.useGlobalPipes(new ValidationPipe());
+
   app.enableCors({
     origin: [
       process.env.ADMIN_APP_BASE_URL || 'http://localhost:5173/',
       process.env.MOBILE_APP_BASE_URL || 'http://localhost:8080/',
     ],
+    credentials: true,
   });
+
+  app.use(cookieParser());
 
   const reflector = app.get(Reflector);
   app.useGlobalGuards(


### PR DESCRIPTION
### Authentication Enhancements:
* **Cookie-based Authentication**: Updated `AuthController` methods (`login`, `logout`, and `refresh`) to use cookies for managing refresh tokens. This includes setting secure, HTTP-only cookies and clearing them during logout.
* **Integration of `cookie-parser`**: Added `cookie-parser` middleware in `src/main.ts` to parse cookies in incoming requests.

### Repository Refactoring:
* **Token Expiration**: Refactored `PrismaRefreshTokenRepository` to delete expired refresh tokens instead of updating.

### Dependency Updates:
* **New Dependencies**: Added `cookie-parser` and its type definitions (`@types/cookie-parser`) to `package.json`.